### PR TITLE
Update APIs in the description of providers

### DIFF
--- a/docs/12-connectors/05-description/20-credential-provider.md
+++ b/docs/12-connectors/05-description/20-credential-provider.md
@@ -51,7 +51,7 @@ The following processes are associated with the Credential Provider and manageme
     @startuml
     autonumber
     skinparam topurl https://docs.czertainly.com/api/
-        Client->Core [[core-credential/#tag/Credential-Management-API/operation/updateCredential]]: Update Credential
+        Client->Core [[core-credential/#tag/Credential-Management-API/operation/editCredential]]: Update Credential
         Core->Core: Check existence of Connector and Credential
         Core->Connector [[connector-credential-provider/#tag/Attributes-API/operation/validateAttributes]]: Validate attributes
         Connector-->Core: Return validation result
@@ -66,7 +66,7 @@ The following processes are associated with the Credential Provider and manageme
     @startuml
     autonumber
     skinparam topurl https://docs.czertainly.com/api/
-        Client->Core [[core-credential/#tag/Credential-Management-API/operation/removeCredential]]: Remove Credential
+        Client->Core [[core-credential/#tag/Credential-Management-API/operation/deleteCredential]]: Remove Credential
         Core->Core: Check if the Credential can be removed
         Core->Core: Remove Credential
         Core-->Client: Return result

--- a/docs/12-connectors/05-description/22-authority-provider-legacy.md
+++ b/docs/12-connectors/05-description/22-authority-provider-legacy.md
@@ -69,7 +69,7 @@ The following processes are associated with the Authority Provider Legacy and ma
     @startuml
     autonumber
     skinparam topurl https://docs.czertainly.com/api/
-        Client -> Core [[core-authority/#tag/Authority-Management-API/operation/updateAuthorityInstance]]: Update Authority instance
+        Client -> Core [[core-authority/#tag/Authority-Management-API/operation/editAuthorityInstance]]: Update Authority instance
         Core -> Connector : Validate Attributes
         Connector --> Core: Result of Attribute validation
         Core -> Connector [[connector-authority-provider-v2/#tag/Authority-Management-API/operation/updateAuthorityInstance]]: Update Authority instance
@@ -89,7 +89,7 @@ The below diagram shows the sequence of messages that are exchanged between the 
     @startuml
     autonumber
     skinparam topurl https://docs.czertainly.com/api/
-        Client -> Core [[core-authority/#tag/Authority-Management-API/operation/removeAuthorityInstance]]: Remove Authority instance
+        Client -> Core [[core-authority/#tag/Authority-Management-API/operation/deleteAuthorityInstance]]: Remove Authority instance
         Core -> Core : Check dependencies
         Core -> Connector [[connector-authority-provider-v2/#tag/Authority-Management-API/operation/removeAuthorityInstance]]: Remove Authority instance
         Connector --> Core: Return Authority Instance deletion response

--- a/docs/12-connectors/05-description/25-authority-provider-v2.md
+++ b/docs/12-connectors/05-description/25-authority-provider-v2.md
@@ -60,7 +60,7 @@ The following processes are associated with the Authority Provider v2 and manage
     @startuml
     autonumber
     skinparam topurl https://docs.czertainly.com/api/
-        Client -> Core [[core-authority/#tag/Authority-Management-API/operation/updateAuthorityInstance]]: Update Authority instance
+        Client -> Core [[core-authority/#tag/Authority-Management-API/operation/editAuthorityInstance]]: Update Authority instance
         Core -> Connector : Validate Attributes
         Connector --> Core: Result of Attribute validation
         Core -> Connector [[connector-authority-provider-v2/#tag/Authority-Management-API/operation/updateAuthorityInstance]]: Update Authority instance
@@ -80,7 +80,7 @@ The below diagram shows the sequence of messages that are exchanged between the 
     @startuml
     autonumber
     skinparam topurl https://docs.czertainly.com/api/
-        Client -> Core [[core-authority/#tag/Authority-Management-API/operation/removeAuthorityInstance]]: Remove Authority instance
+        Client -> Core [[core-authority/#tag/Authority-Management-API/operation/deleteAuthorityInstance]]: Remove Authority instance
         Core -> Core : Check dependencies
         Core -> Connector [[connector-authority-provider-v2/#tag/Authority-Management-API/operation/removeAuthorityInstance]]: Remove Authority instance
         Connector --> Core: Return Authority Instance deletion response

--- a/docs/12-connectors/05-description/27-discovery-provider.md
+++ b/docs/12-connectors/05-description/27-discovery-provider.md
@@ -69,7 +69,7 @@ The following processes are associated with the Discovery Provider and managemen
     @startuml
     autonumber
     skinparam topurl https://docs.czertainly.com/api/
-        Client -> Core [[core-discovery/#tag/Discovery-Management-API/operation/removeDiscovery]]: Remove Discovery
+        Client -> Core [[core-discovery/#tag/Discovery-Management-API/operation/deleteDiscovery]]: Remove Discovery
         Core -> Connector [[connector-discovery-provider/#tag/Discovery-API/operation/deleteDiscovery]]: Delete Discovery
         Connector --> Core: Discovery removed
         Core -> Core : Remove Discovery

--- a/docs/12-connectors/05-description/32-entity-provider.md
+++ b/docs/12-connectors/05-description/32-entity-provider.md
@@ -110,7 +110,7 @@ The following processes are associated with the Entity Provider and management o
     @startuml
     autonumber
     skinparam topurl https://docs.czertainly.com/api/
-        Client -> Core [[core-Entity/#tag/Entity-Management-API/operation/updateEntityInstance]]: Update Entity instance
+        Client -> Core [[core-Entity/#tag/Entity-Management-API/operation/editEntityInstance]]: Update Entity instance
         note over Client,Core: Update Existing Entity with Attributes from the connector
         Core -> Connector [[core-Entity/#tag/Entity-Management-API/operation/validateLocationAttributes]]: Validate Attributes
         Connector --> Core: Result of attribute validation
@@ -130,7 +130,7 @@ The following processes are associated with the Entity Provider and management o
     @startuml
     autonumber
     skinparam topurl https://docs.czertainly.com/api/
-        Client -> Core [[core-Entity/#tag/Entity-Management-API/operation/removeEntityInstance]]: Remove Entity instance
+        Client -> Core [[core-Entity/#tag/Entity-Management-API/operation/deleteEntityInstance]]: Remove Entity instance
         Core -> Core: Check for dependent objects
         Core -> Connector [[core-Entity/#tag/Entity-Management-API/operation/removeEntityInstance]]: Remove Entity instance
         Connector --> Core: Entity Instance removed
@@ -198,7 +198,7 @@ The following processes are associated with the Entity Provider and management o
     @startuml
     autonumber
     skinparam topurl https://docs.czertainly.com/api/
-        Client -> Core [[core-location/#tag/Location-Management-API/operation/removeLocation]]: Remove Location
+        Client -> Core [[core-location/#tag/Location-Management-API/operation/deleteLocation]]: Remove Location
         Core -> Core: Check for dependent objects
         Core -> Core: Remove Location
         Core --> Client: Location details
@@ -250,10 +250,8 @@ The following processes are associated with the Entity Provider and management o
     @startuml
     autonumber
     skinparam topurl https://docs.czertainly.com/api/
-        Client -> Core [[core-location/#tag/Location-Management-API/operation/renewCertificateInLocation]]: Remove Certificate from Location
+        Client -> Core [[core-location/#tag/Location-Management-API/operation/renewCertificateInLocation]]: Renew Certificate in Location
         Core -> Core: Perform Pre Checks for Certificate Renewal
-        Core -> Connector [[connector-entity-provider/#tag/Location-Operations-API/operation/removeCertificateFromLocation]]: Remove Certificate
-        Connector --> Core: Result of Certificate deletion
         Core -> Connector [[connector-entity-provider/#tag/Location-Operations-API/operation/validateGenerateCsrAttributes]]: Validate CSR Attributes
         Connector --> Core: Result of CSR Attribute validation
         Core -> Connector [[connector-entity-provider/#tag/Location-Operations-API/operation/generateCsrLocation]]: Generate CSR

--- a/docs/12-connectors/05-description/32-entity-provider.md
+++ b/docs/12-connectors/05-description/32-entity-provider.md
@@ -226,9 +226,11 @@ The following processes are associated with the Entity Provider and management o
     autonumber
     skinparam topurl https://docs.czertainly.com/api/
         Client -> Core [[core-location/#tag/Location-Management-API/operation/issueCertificate]]: Issue Certificate to Location
+        Core -> Core: Perform Pre Checks for Certificate Issuance
         Core -> Connector [[connector-entity-provider/#tag/Location-Operations-API/operation/validateGenerateCsrAttributes]]: Validate CSR Attributes
         Connector --> Core: Result of CSR Attribute validation
         Core -> Connector [[connector-entity-provider/#tag/Location-Operations-API/operation/generateCsrLocation]]: Generate CSR
+        Connector -> Connector: Generate CSR with new Key Pair
         Connector --> Core: CSR Data
         Core -> Authority [[connector-authority-provider-v2/#tag/Certificate-Management-API/operation/issueCertificate]]: Issue Certificate
         Authority --> Core: Base64 Certificate
@@ -249,11 +251,13 @@ The following processes are associated with the Entity Provider and management o
     autonumber
     skinparam topurl https://docs.czertainly.com/api/
         Client -> Core [[core-location/#tag/Location-Management-API/operation/renewCertificateInLocation]]: Remove Certificate from Location
+        Core -> Core: Perform Pre Checks for Certificate Renewal
         Core -> Connector [[connector-entity-provider/#tag/Location-Operations-API/operation/removeCertificateFromLocation]]: Remove Certificate
         Connector --> Core: Result of Certificate deletion
         Core -> Connector [[connector-entity-provider/#tag/Location-Operations-API/operation/validateGenerateCsrAttributes]]: Validate CSR Attributes
         Connector --> Core: Result of CSR Attribute validation
         Core -> Connector [[connector-entity-provider/#tag/Location-Operations-API/operation/generateCsrLocation]]: Generate CSR
+        Connector -> Connector: Generate CSR with existing Key Pair
         Connector --> Core: CSR Data
         Core -> Authority [[connector-authority-provider-v2/#tag/Certificate-Management-API/operation/renewCertificate]]: Renew Certificate
         Authority --> Core: Base64 Certificate


### PR DESCRIPTION
This PR Contains the changes for the following:

1. Update the description of processes involved in issuing and renewing certificate in the location
2. Update the links of the API calls in the connector description based on release 2.5.0