### PR TITLE
clarify how to exec Docusarus especialy on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ To learn how to work with Docusaurus, refer to the [Docusaurus documentation](ht
 
 ## How to work with the documentation
 
+- Install [`npm`](https://github.com/nodesource/distributions) from offical site.
+- Install [`yarn`](https://yarnpkg.com/getting-started/install) from offical site.
 - Use `yarn install` for installation of the documentation modules and dependencies.
-- Use `yarn start` for starting a local development server and opens up a browser window.
+- Use `yarn start` to start a local development server providing a rendered version of your local copy of the documentation. It will be typically available on http://localhost:3000/ and browser window should automatically open up for you.
 - Use `yarn build` for building the documentation. This command generates static content into the `build` directory.
+
+### Notes for running on a Debian Linux
+
+The versions of `npm` and `yarn` (provided as `yarnpkg`) are obsoleted in Debian 10. It is possible to download `npm` packaged as a Debian package from the official site listed above.
+
+`yarn` is not officially provided as a Debian package. The [official installation](https://yarnpkg.com/getting-started/install) process requires root privileges. It is possible to install it locally using `npm install yarn` into the current directory, for example, if you exec install in your home, it will create `node_modules` directory with all its components. Later it can be used as `~/mode_modules/.bin/yarn start` to execute local development server showing a rendered version of the documentation.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > This repository is part of the open source project CZERTAINLY. You can find more information about the project at [CZERTAINLY](https://github.com/3KeyCompany/CZERTAINLY) repository, including the contribution guide.
 
-CZERTAINLY documentation is built using [Docusaurus 2](https://docusaurus.io/), a modern static website generator.
+CZERTAINLY documentation is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
 
 ## How to contribute
 
@@ -11,16 +11,21 @@ For the contribution guide to the CZERTAINLY, refer to [CZERTAINLY](https://gith
 
 To learn how to work with Docusaurus, refer to the [Docusaurus documentation](https://docusaurus.io/docs/).
 
+> [!IMPORTANT]  
+> Check the [Docusaurus requirements](https://docusaurus.io/docs/installation#requirements) when you are setting up your environment for the first time and would like to run the documentation locally.
+
+> [!NOTE]  
+> Installation of the prerequisites may differ based on your operating system. Check the instruction for your operating system before you start the installation.
+
 ## How to work with the documentation
 
-- Install [`npm`](https://github.com/nodesource/distributions) from offical site.
-- Install [`yarn`](https://yarnpkg.com/getting-started/install) from offical site.
 - Use `yarn install` for installation of the documentation modules and dependencies.
 - Use `yarn start` to start a local development server providing a rendered version of your local copy of the documentation. It will be typically available on http://localhost:3000/ and browser window should automatically open up for you.
 - Use `yarn build` for building the documentation. This command generates static content into the `build` directory.
 
-### Notes for running on a Debian Linux
+> [!NOTE]  
+> You can use `npm` instead of `yarn` for the same purpose. The `yarn` is a package manager that doubles as project manager. It is a good alternative to `npm` and it is recommended to use it for the development of the CZERTAINLY documentation.
 
-The versions of `npm` and `yarn` (provided as `yarnpkg`) are obsoleted in Debian 10. It is possible to download `npm` packaged as a Debian package from the official site listed above.
+## How to deploy the documentation
 
-`yarn` is not officially provided as a Debian package. The [official installation](https://yarnpkg.com/getting-started/install) process requires root privileges. It is possible to install it locally using `npm install yarn` into the current directory, for example, if you exec install in your home, it will create `node_modules` directory with all its components. Later it can be used as `~/mode_modules/.bin/yarn start` to execute local development server showing a rendered version of the documentation.
+The CZERTAINLY documentation is deployed to the GitHub pages. The deployment is done automatically by the GitHub Actions when the changes are merged to the `gh-pages` branch.


### PR DESCRIPTION
As a person who has no experience with NodeJS I find existing documentation hard to use. Here is enhanced version which I hope will be more clear.