### PR TITLE
Remove dangling virtual appliance shutdown link

### DIFF
--- a/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/05-operations.md
+++ b/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/05-operations.md
@@ -9,7 +9,7 @@ The following document describes advanced operations for the management of virtu
 
 ### Shut down
 
-To shut down the virtual appliance use ACPI shutdown call of your virtualization platform or select **Advanced options -> [Shutdown system](./TUI/advanced-menu#shutdown-system)**.
+To shut down the virtual appliance use ACPI shutdown call of your virtualization platform or select **Advanced options -> Shutdown system**.
 
 ### Restart
 


### PR DESCRIPTION
I think that Shutdown is self explanatory, it doesn't need extra section in documentation. So I'm removing dangling link.