### PR TITLE
claryfing version numbers in Appliance scope

### DIFF
--- a/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/01-overview.md
+++ b/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/01-overview.md
@@ -24,10 +24,10 @@ Because of different availability and public/private access to containers, the v
 | Resource | Optimum | Minimum |
 |----------|---------|---------|
 | CPU      | 8 cores | 4 cores |
-| RAM      | 16 GB   | 8 GB    |
+| RAM      | 16 GB   | 12 GB   |
 | disk     | 50 GB   | 20 GB   |
 
-By *minimum* requirements we mean resources which needed for CZERTAINLY and kubernetes installation and for basic evaluation of its features.
+By *minimum* requirements we mean resources which are needed for CZERTAINLY with all configurable componets and kubernetes installation and for basic evaluation of its features.
 
 :::tip[Resource management]
 Resources can be scaled up or down based on the needs of the platform. The resources needed for the CZERTAINLY platform differs based on the number of managed objects, implemented use-cases, and required connectors.

--- a/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/01-overview.md
+++ b/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/01-overview.md
@@ -36,9 +36,9 @@ Resources can be scaled up or down based on the needs of the platform. The resou
 ## Download and import image
 
 To get the virtual appliance running in your environment for further  installation  and configuration, you must:
-1. Download virtual appliance [image](https://threekeycz-my.sharepoint.com/:f:/g/personal/jan_tomasek_3key_company/EvTNcHQYa4BInbGsK-YSGHkBIx9V6DfAxnMKqrvWdEB8NA?e=ujoUdt).
+1. Download virtual appliance [image](https://threekeycz-my.sharepoint.com/:f:/g/personal/jan_tomasek_3key_company/EvTNcHQYa4BInbGsK-YSGHkB7BTKvI9JCZJJaQx2KC6eBw).
 2. Optionally verify SHA256 hash of the image.
-2. Import virtual appliance image to your virtual infrastructure.
+3. Import virtual appliance image to your virtual infrastructure.
 
 For testing purposes, you can use:
 - [Oracle VirtualBox](https://www.virtualbox.org/wiki/Downloads)

--- a/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/05-operations.md
+++ b/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/05-operations.md
@@ -105,7 +105,7 @@ For your convenience, we provide the script `czertainly-versions --detailed` whi
 ### Upgrading
 
 :::warning
-Before any upgrade process make sure you have a recent snapshot first!
+Before any upgrade make sure you have a recent snapshot first!
 :::
 
 #### OS packages upgrades

--- a/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/05-operations.md
+++ b/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/05-operations.md
@@ -105,7 +105,7 @@ For your convenience, we provide the script `czertainly-versions --detailed` whi
 ### Upgrading
 
 :::warning
-Before any upgrade make sure you have a recent snapshot first!
+Before any upgrade, make sure you have a recent snapshot first!
 :::
 
 #### OS packages upgrades

--- a/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/05-operations.md
+++ b/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/05-operations.md
@@ -90,10 +90,22 @@ If you need to provide your own custom Helm chart values that are not available 
 
 The custom values overwrite the default values during the installation/upgrade process.
 
+### Versioning
+
+There are three versions which are related to CZERTAINLY Virtual Appliance.
+
+First, there is a version of **CZERTAINLY Appliance** which is recorded in the file `/etc/czertainly_appliance_version`. The appliance version provides a clue to Debian which was used as a base for the Appliance. This is also why this number is not changed during upgrades.
+
+Next, we have a version of **CZERTAINLY Appliance Tools**. Tools are the core of the Appliance, they come with Ansible Playbooks, Roles and TUI. The tools are distributed as a Debian package and actually instaled version can be displayed by the command `apt -q show czertainly-appliance-tools`. It is perfectly OK to have a higher version of the Tools than of the Appliance, it is the right way how to get new versions of CZERTAINLY itself to the Appliance.
+
+And finally, there is a version of **CZERTAINLY**. Which itself breaks into several components with their [independent versioning](../../../30-current-versions.md), but the main version is defined by the version of the Core and the Helm Chart. You can learn a version of the Helm Chart by running `helm -n czertainly list`.
+
+For your convenience, we provide the script `czertainly-versions --detailed` which displays a list of all relevant versions for your CZERTAINLY.
+
 ### Upgrading
 
 :::warning
-Before any upgrade process make sure you have recent snapshot first!
+Before any upgrade process make sure you have a recent snapshot first!
 :::
 
 #### OS packages upgrades
@@ -160,22 +172,11 @@ Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
 Server Version: v1.30.4+rke2r1
 ```
 
-
 #### CZERTAINLY upgrade
 
-It is possible to upgrade CZERTAINLY just by raising the version number in [CZERTAINLY configuration](./TUI/main-menu#configure-czertainly) and executing [CZERTAINLY Instalation](./TUI/main-menu#install-czertainly). It should work for upgrades from version 2.8.0 upwards, but you have to raise the minor version number by 1.
+It is possible to upgrade CZERTAINLY just by raising the version number in [CZERTAINLY configuration](./TUI/main-menu#configure-czertainly) and executing [CZERTAINLY Instalation](./TUI/main-menu#install-czertainly). It should work for upgrades from version 2.8.0 upwards.
 
-We recommend removing all CZERTAINLY components and installing them back, database with all configurations and all your certificates is untouched during this task. This process involves downtime. Follow the tasks:
-
-Perform [OS upgrade](#os-upgrades). Log out and re-login to open a new session of the TUI.
-
-From the Advanced menu select [Remove RKE2 & CZERTAINLY](./TUI/advanced-menu#remove-rke2--czertainly) this task will remove the Kubernetes cluster together with CZERTAINLY. The database is installed on the OS so it will remain untouched together with CZERTAINLY settings stored in `/etc/czertainly-ansible/vars/`. It is quite quick.
-
-[Configure parameters of email server](./TUI/main-menu#configure-email-server-parameters), this is a new feature of 2.9.0. If you are sure that you do not need notification services, you can disable it in [CZERTAINLY configuration](./TUI/main-menu#configure-czertainly). If you leave the default settings with `hostname` = `mail.example.com` the installation will hang and later timeout.
-
-From version 2.9.0 is it possible to install KeyCloak to allow logging by using username/password. Installing KeyCloak takes some more time, if you are not planning to use it and continue to use certificates, disable KeyCloak inside [CZERTAINLY configuration](./TUI/main-menu#configure-czertainly).
-
-Execute [Install CZETAINLY](TUI/main-menu#install-czertainly) from the main menu. This task will execute Ansible to install the Kubernetes cluster and later to install CZERTAINLY.
+We strongly recommend first performing [OS packages upgrades](#os-packages-upgrades) to upgrade OS components and to get the latest version of [CZERTAINLY Appliance Tools](#versioning). If you upgrade the Tools first you get support for all new CZERTAINLY components directly in TUI.
 
 ### Backup
 

--- a/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/05-operations.md
+++ b/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/05-operations.md
@@ -92,7 +92,7 @@ The custom values overwrite the default values during the installation/upgrade p
 
 ### Versioning
 
-There are three versions which are related to CZERTAINLY Virtual Appliance.
+There are three version numbers which are related to CZERTAINLY Virtual Appliance.
 
 First, there is a version of **CZERTAINLY Appliance** which is recorded in the file `/etc/czertainly_appliance_version`. The appliance version provides a clue to Debian which was used as a base for the Appliance. This is also why this number is not changed during upgrades.
 

--- a/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/05-operations.md
+++ b/docs/10-certificate-key/03-installation-guide/04-deployment/06-deployment-appliance/05-operations.md
@@ -125,6 +125,41 @@ In case you decide to upgrade your Virtual appliance based on Debian Bullseye, y
  * [restore](#restore) database,
  * re-run CZERTAINLY installation from the main menu.
 
+#### Kubernetes upgrades
+
+CZERTAINLY Virtual Appliance is using [RKE2](https://docs.rke2.io/) as Kubernetes distribution, latest version can be checked in their [Relase Notes](https://docs.rke2.io/release-notes/v1.31.X). The actual running version on Appliance can be checked by the shell command `kubectl version`. Example output:
+```bash
+$ kubectl version
+Client Version: v1.28.11+rke2r1
+Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
+Server Version: v1.28.11+rke2r1
+```
+
+To upgrade exec "Install CZERTAINLY" from the main menu. This will download the a version of the RKE2 installer, which you can see in the Ansible output:
+```
+TASK [rke2 : download rke2 installer] ******************************************
+changed: [localhost]
+```
+Exec installer from shell command `sudo /usr/local/bin/rke2-install.sh`, example output:
+```bash
+$ sudo /usr/local/bin/rke2-install.sh
+[sudo] password for czertainly:
+[INFO]  finding release for channel stable
+[INFO]  using v1.30.4+rke2r1 as release
+[INFO]  downloading checksums at https://github.com/rancher/rke2/releases/download/v1.30.4+rke2r1/sha256sum-amd64.txt
+[INFO]  downloading tarball at https://github.com/rancher/rke2/releases/download/v1.30.4+rke2r1/rke2.linux-amd64.tar.gz
+[INFO]  verifying tarball
+[INFO]  unpacking tarball file to /usr/local
+```
+This downloads and deploys a new version of RKE2. Next, you need to restart RKE2. Exec `sudo systemctl restart rke2-server.service` and finally verify that Kubernetes was upgraded:
+
+```bash
+$ kubectl version
+Client Version: v1.30.4+rke2r1
+Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
+Server Version: v1.30.4+rke2r1
+```
+
 
 #### CZERTAINLY upgrade
 


### PR DESCRIPTION
I've got impression that there is to much version numbers. Not only in Appliance but in our project in general. But I've no idea how to reduce them so at least tried to explain a bit.