### PR TITLE
Update Keycloak integration guide

### DIFF
--- a/docs/certificate-key/integration-guides/keycloak/create-realm.md
+++ b/docs/certificate-key/integration-guides/keycloak/create-realm.md
@@ -30,7 +30,7 @@ To create new OIDC client, follow steps described in [Creating an OpenID Connect
 - Name: **czertainly**
 - Client authentication: **On**
 - Root URL: **https://\<CZERTAINLY_DOMAIN>**, where `<CZERTAINLY_DOMAIN>` is the domain of your CZERTAINLY instance. This serves as an access point to your deployment
-- Valid redirect URIs: URI pointing to redirect in Core after login via Keycloak, must contain `https://<CZERTAINLY_DOMAIN>/api/login/oauth2/code/<oauth2ProviderName>`, where ``oauth2ProviderName`` is a name of OAuth2 Provider configured in settings **SETTINGS OF WHAT**
+- Valid redirect URIs: URI pointing to redirect in Core after login via Keycloak, must contain `https://<CZERTAINLY_DOMAIN>/api/login/oauth2/code/<oauth2ProviderName>`, where `oauth2ProviderName` is the `providerName` of OAuth2 Provider configured in platform [settings](/api/core-other#tag/Settings/operation/updateOAuth2ProviderSettings)
 - Valid post logout redirect URIs: list of valid post logout redirect URIs, for example `https://<CZERTAINLY_DOMAIN>/administrator/`
 
 :::warning[URIs and origins]

--- a/docs/certificate-key/integration-guides/keycloak/create-realm.md
+++ b/docs/certificate-key/integration-guides/keycloak/create-realm.md
@@ -26,13 +26,12 @@ To create a new realm, follow steps in [Creating a realm](https://www.keycloak.o
 To create new OIDC client, follow steps described in [Creating an OpenID Connect client](https://www.keycloak.org/docs/latest/server_admin/#proc-creating-oidc-client_server_administration_guide) with the following attributes:
 
 - Client type: **OpenID Connect**
-- Client ID: **CZERTAINLY**
-- Name: **CZERTAINLY**
+- Client ID: **czertainly**
+- Name: **czertainly**
 - Client authentication: **On**
 - Root URL: **https://\<CZERTAINLY_DOMAIN>**, where `<CZERTAINLY_DOMAIN>` is the domain of your CZERTAINLY instance. This serves as an access point to your deployment
-- Valid redirect URIs: URI pointing to redirect in Core after login via Keycloak, must contain `https://<CZERTAINLY_DOMAIN>/api/login/oauth2/code/<oauth2ProviderName>`, where ``oauth2ProviderName`` is a name of OAuth2 Provider configured in settings
+- Valid redirect URIs: URI pointing to redirect in Core after login via Keycloak, must contain `https://<CZERTAINLY_DOMAIN>/api/login/oauth2/code/<oauth2ProviderName>`, where ``oauth2ProviderName`` is a name of OAuth2 Provider configured in settings **SETTINGS OF WHAT**
 - Valid post logout redirect URIs: list of valid post logout redirect URIs, for example `https://<CZERTAINLY_DOMAIN>/administrator/`
-- Web origins: list of valid web origins, for example `https://<CZERTAINLY_DOMAIN>`
 
 :::warning[URIs and origins]
 Valid URIs and web origins should be properly configured to avoid any security related issues, for example Cross-origin resource sharing (CORS) issues.
@@ -45,8 +44,9 @@ The user in the platform is identified using JWT Access Token as described in th
 Based on the attributes coming from the configuration of the identity provider, proper mappers for the dedicated scope should be created.
 For more information, see [OIDC token and SAML assertion mappings](https://www.keycloak.org/docs/latest/server_admin/#_protocol-mappers) in the Keycloak documentation.
 
-As an example, if you want to create mapper that will map `groups` attributes (that are sent from Active Directory) to array of `roles` in the JWT Claims Set, you can use the following configuration:
+As an example, for situation you are going to use manual user management in Keycloak, you need to create mapper that will map `groups` attributes to array of `roles` in the JWT Claims Set. After adding **czertainly** client, click on **Client scopes tab**, select **czertainly-dedicated** and add following mappers:
 
+#### Groups Mapper
 - Mapper type: **User Attribute**
 - Name: **Groups**
 - User Attribute: **groups**
@@ -54,6 +54,30 @@ As an example, if you want to create mapper that will map `groups` attributes (t
 - Claim JSON Type: **String**
 - Add to ID token: **On**
 - Add to access token: **On**
+- Add to lightweight access token: **Off**
 - Add to userinfo: **On**
+- Add to token introspection: **On**
 - Multivalued: **On**
 - Aggregate attribute values: **Off**
+
+#### Audience Mapper
+- Mapper type: **Audience**
+- Name: **Audience**
+- Included Client Audience: **czertainly**
+- Included Custom Audience: **empty**
+- Add to ID token: **On**
+- Add to access token: **On**
+- Add to lightweight access token: **Off**
+- Add to token introspection: **On**
+
+#### Username Mapper
+- Mapper type: **User Property**
+- Name: **Username**
+- Property: **username**
+- Token Claim Name: **username**
+- Claim JSON Type: **String**
+- Add to ID token: **On**
+- Add to access token: **On**
+- Add to lightweight access token: **Off**
+- Add to userinfo: **On**
+- Add to token introspection: **On**

--- a/docs/certificate-key/integration-guides/keycloak/create-user-login.md
+++ b/docs/certificate-key/integration-guides/keycloak/create-user-login.md
@@ -43,5 +43,5 @@ authService:
 ## Login
 
 You can login to CZERTAINLY with configured user:
-- Open the CZERTAINLY login page: `https://<CZERTAINLY_DOMAIN>/login`
+- Open the CZERTAINLY login page: `https://<CZERTAINLY_DOMAIN>/login?redirect=%2Fadministrator%2F`
 - Login with username `admin`

--- a/docs/certificate-key/integration-guides/keycloak/overview.md
+++ b/docs/certificate-key/integration-guides/keycloak/overview.md
@@ -35,7 +35,6 @@ The following steps should be done to integrate Keycloak with CZERTAINLY:
 
 ## Identity providers
 
-Keycloak supports multiple identity providers.
-You can configure identity providers together with appropriate attribute mapping to allow users to login to CZERTAINLY with their existing accounts.
+For the first experiments with Keycloak, you would probably just [create local users](create-user-login.md).
 
-For more information, refer to [Identity Providers](https://www.keycloak.org/docs/latest/server_admin/#_identity_broker) in the Keycloak documentation.
+For production, you can configure Identity Providers together with appropriate attribute mapping to allow users to log in to CZERTAINLY with their existing accounts from your organizational IdP. Keycloak supports multiple identity providers. For more information, refer to [Identity Providers](https://www.keycloak.org/docs/latest/server_admin/#_identity_broker) in the Keycloak documentation. You can also use our guide to integrate with [MS Active Directory Federation Services](../adfs/overview.mdx).

--- a/docs/certificate-key/integration-guides/keycloak/overview.md
+++ b/docs/certificate-key/integration-guides/keycloak/overview.md
@@ -37,4 +37,8 @@ The following steps should be done to integrate Keycloak with CZERTAINLY:
 
 For the first experiments with Keycloak, you would probably just [create local users](create-user-login.md).
 
-For production, you can configure Identity Providers together with appropriate attribute mapping to allow users to log in to CZERTAINLY with their existing accounts from your organizational IdP. Keycloak supports multiple identity providers. For more information, refer to [Identity Providers](https://www.keycloak.org/docs/latest/server_admin/#_identity_broker) in the Keycloak documentation. You can also use our guide to integrate with [MS Active Directory Federation Services](../adfs/overview.mdx).
+For production, you can configure Identity Providers together with appropriate attribute mapping to allow users to log in to CZERTAINLY with their existing accounts from your organizational IdP. Keycloak supports multiple identity providers. For more information, refer to [Identity Providers](https://www.keycloak.org/docs/latest/server_admin/#_identity_broker) in the Keycloak documentation.
+
+:::tip[MS Active Directory Federation Services]
+You can also use [MS Active Directory Federation Services](../adfs/overview.mdx) integration guide for more information on how to federate AD users with Keycloak.
+:::


### PR DESCRIPTION
I tried to update Keycloak to be closer to reality. I need help with sentence:

Valid redirect URIs: URI pointing to redirect in Core after login via Keycloak, must contain `https://<CZERTAINLY_DOMAIN>/api/login/oauth2/code/<oauth2ProviderName>`, where ``oauth2ProviderName`` is a name of OAuth2 Provider configured in settings

I do not know where should I get info that oauth2ProviderName = internal in our typical deployment.