### PR TITLE
Update link to Core interfaces documentation

### DIFF
--- a/docs/certificate-key/concept-design/architecture/interfaces.md
+++ b/docs/certificate-key/concept-design/architecture/interfaces.md
@@ -50,4 +50,4 @@ Each `Connector` has to implement at least the following interfaces:
 `Core` interfaces are used by the platform to communicate with the `Connector` and the `Client`.
 
 You can find the description of the `Core` interfaces in the following sections:
-- [Core interfaces](https://github.com/CZERTAINLY/CZERTAINLY-Interfaces/tree/develop/src/main/java/com/czertainly/api/interfaces/core)
+- [Core interfaces](https://github.com/CZERTAINLY/CZERTAINLY-Interfaces/tree/main/src/main/java/com/czertainly/api/interfaces/core)


### PR DESCRIPTION
A broken link to a non-existent develop branch was updated to point to the main branch.