### PR TITLE
Add local environment setup guide to QA strategy

### DIFF
--- a/docs/certificate-key/installation-guide/create-super-administrator.md
+++ b/docs/certificate-key/installation-guide/create-super-administrator.md
@@ -8,6 +8,9 @@ When you deploy the platform for the first time, there are no Super Administrato
 
 To register the first Administrator, you need to use `Local API`, which is accessible only from the `localhost` of the `Core` deployment. The `Local API` does not require the X.509 client certificate based authentication.
 
+> [!IMPORTANT]
+> When the platform is deployed using **Docker Compose**, the Core service runs inside a container. The `Local API` is only reachable from within the container — calling it directly from the host machine will return HTTP 401. Use `docker exec` to run the request inside the container (see examples below).
+
 ## Register first Administrator
 You can use any tool or command line utility to access the `Local API` and register the first Administrator.
 
@@ -27,16 +30,25 @@ You need to provide the following information:
 }
 ```
 
-The following example is using `curl`:
+The following example is using `curl` for a **standalone deployment** (Core running directly on the host):
 
 ```bash
 curl -X POST \
  -H 'content-type: application/json' \
  -d @first-admin.json \
- https://localhost:8080/api/v1/local/admins 
+ http://localhost:8080/api/v1/local/admins
 ```
 
-Using the `wget`:
+When running with **Docker Compose**, use `docker exec` to execute the request from inside the Core container:
+
+```bash
+docker exec core curl -X POST \
+ -H 'content-type: application/json' \
+ -d @first-admin.json \
+ http://localhost:8080/api/v1/local/admins
+```
+
+Using `wget` for a **standalone deployment**:
 
 ```bash
 wget -O- --header='Content-Type:application/json' \

--- a/docs/certificate-key/installation-guide/create-super-administrator.md
+++ b/docs/certificate-key/installation-guide/create-super-administrator.md
@@ -8,9 +8,6 @@ When you deploy the platform for the first time, there are no Super Administrato
 
 To register the first Administrator, you need to use `Local API`, which is accessible only from the `localhost` of the `Core` deployment. The `Local API` does not require the X.509 client certificate based authentication.
 
-> [!IMPORTANT]
-> When the platform is deployed using **Docker Compose**, the Core service runs inside a container. The `Local API` is only reachable from within the container — calling it directly from the host machine will return HTTP 401. Use `docker exec` to run the request inside the container (see examples below).
-
 ## Register first Administrator
 You can use any tool or command line utility to access the `Local API` and register the first Administrator.
 
@@ -30,25 +27,16 @@ You need to provide the following information:
 }
 ```
 
-The following example is using `curl` for a **standalone deployment** (Core running directly on the host):
+The following example is using `curl`:
 
 ```bash
 curl -X POST \
  -H 'content-type: application/json' \
  -d @first-admin.json \
- http://localhost:8080/api/v1/local/admins
+ https://localhost:8080/api/v1/local/admins 
 ```
 
-When running with **Docker Compose**, use `docker exec` to execute the request from inside the Core container:
-
-```bash
-docker exec core curl -X POST \
- -H 'content-type: application/json' \
- -d @first-admin.json \
- http://localhost:8080/api/v1/local/admins
-```
-
-Using `wget` for a **standalone deployment**:
+Using the `wget`:
 
 ```bash
 wget -O- --header='Content-Type:application/json' \

--- a/docs/qa-strategy/local-setup.md
+++ b/docs/qa-strategy/local-setup.md
@@ -151,7 +151,7 @@ curl http://localhost:8280/api/v1/health/liveness
 The platform uses X.509 certificate-based authentication. To register the first administrator, use the Local API.
 
 :::important
-The Local API is only accessible from **within the Core container**. Calling it directly from the host machine (e.g. `localhost:8280`) returns HTTP 401. Use `docker exec` as shown below.
+The Local API listens only on the container's internal port `8080` and requires no authentication. The externally-mapped port `8280` exposes the regular API, which requires client-cert auth and returns HTTP 401 without one. Use `docker exec` to call the Local API from inside the container.
 :::
 
 Save the administrator payload to a file:
@@ -205,17 +205,14 @@ The platform authenticates API requests using the `ssl-client-cert` header. The 
 Generate the URL-encoded certificate:
 
 ```bash
-CERT_URL=$(python3 -c "
-import urllib.parse
-print(urllib.parse.quote(open('/tmp/admin_cert_b64.txt').read().strip()))
-")
+CERT_URL=$(node -e "const fs=require('fs');console.log(encodeURIComponent(fs.readFileSync('/tmp/admin_cert_b64.txt','utf8').trim()))")
 ```
 
 Verify authentication:
 
 ```bash
 curl -s http://localhost:8280/api/v1/auth/profile \
-  -H "ssl-client-cert: $CERT_URL" | python3 -m json.tool
+  -H "ssl-client-cert: $CERT_URL" | jq
 ```
 
 A successful response returns your administrator profile with role `superadmin` and a full list of permissions.
@@ -238,10 +235,7 @@ curl -s https://raw.githubusercontent.com/OmniTrustILM/helm-charts/main/dummy-ce
   | grep -A 999 "BEGIN CERTIFICATE" | grep -v "BEGIN\|END" | tr -d '\n' \
   > /tmp/admin_cert_b64.txt
 
-CERT_URL=$(python3 -c "
-import urllib.parse
-print(urllib.parse.quote(open('/tmp/admin_cert_b64.txt').read().strip()))
-")
+CERT_URL=$(node -e "const fs=require('fs');console.log(encodeURIComponent(fs.readFileSync('/tmp/admin_cert_b64.txt','utf8').trim()))")
 
 cat > src/setupProxy.js << EOF
 const proxyConfig = {
@@ -297,7 +291,7 @@ Data in the database is persisted in the `./data/` directory. To reset the platf
 | `docker ps` fails with daemon error | Docker Desktop not started | Start Docker Desktop and wait for the icon to stop animating |
 | `docker compose up` fails on secrets mount | `secrets/trusted_certificates.pem` does not exist | Run `touch secrets/trusted_certificates.pem` |
 | Auth returns `User client certificate is invalid` | Dummy Root CA not in trusted certs | Add Root CA to `secrets/trusted_certificates.pem` and restart auth: `docker compose ... restart auth` |
-| Local API returns HTTP 401 from host | Local API is container-only | Use `docker exec core curl ...` instead of calling `localhost:8280` directly |
+| Local API returns HTTP 401 from host | Port `8280` is the regular API requiring cert auth; Local API is on container-internal port `8080` only | Use `docker exec core curl ...` instead of calling `localhost:8280` directly |
 | Authentication returns `Wrong format of user authentication certificate` | Certificate not URL-encoded | Use `urllib.parse.quote()` to URL-encode the certificate before sending |
 | `CZERTAINLY_SOURCES_BASE_DIR` not found | Wrong path in `.env` | Set the full absolute path to the directory containing `auth`, `auth-opa-policies`, `scheduler` |
 | Frontend shows blank page or API errors | `setupProxy.js` missing or wrong cert | Recreate `src/setupProxy.js` following Step 8 |

--- a/docs/qa-strategy/local-setup.md
+++ b/docs/qa-strategy/local-setup.md
@@ -36,7 +36,7 @@ Clone the environment configuration repository:
 git clone https://github.com/OmniTrustILM/development-environment.git
 ```
 
-Clone the three services that are built from source. The folder names must match exactly as shown:
+Clone the three services that are built from source. The folder names must match exactly as shown — the repositories were renamed, but `czertainly-compose.yml` build paths still reference the original `CZERTAINLY-*` names:
 
 ```bash
 git clone https://github.com/OmniTrustILM/auth.git CZERTAINLY-Auth
@@ -73,7 +73,9 @@ cp .env.example .env
 Open `.env` in any text editor and update `CZERTAINLY_SOURCES_BASE_DIR` to point to your working directory:
 
 ```env
-CZERTAINLY_SOURCES_BASE_DIR=/Users/yourname/ilm-local
+# macOS:  /Users/yourname/ilm-local
+# Linux:  /home/yourname/ilm-local
+CZERTAINLY_SOURCES_BASE_DIR=<absolute path to ilm-local>
 ```
 
 All other values can be left at their defaults when using PostgreSQL in Docker.

--- a/docs/qa-strategy/local-setup.md
+++ b/docs/qa-strategy/local-setup.md
@@ -4,7 +4,7 @@ sidebar_position: 5
 
 # Local Environment Setup
 
-This guide walks you through setting up the ILM platform locally using Docker Compose. By the end, you will have a fully running platform with all core services, a registered administrator, and a verified API connection — ready for writing automation tests.
+This guide walks you through setting up the ILM platform locally using Docker Compose. By the end, you will have a fully running platform with all core services, a registered administrator, a working UI at `localhost:5173`, and a verified API connection — ready for writing automation tests.
 
 ## Prerequisites
 
@@ -12,6 +12,7 @@ Make sure the following are installed before you begin:
 
 - **Docker Desktop** — [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/). After installing, start it and wait until the Docker icon in the system tray stops animating.
 - **Git** — verify with `git --version` in the terminal.
+- **Node.js 18+** — verify with `node --version`. Download from [nodejs.org](https://nodejs.org/).
 
 Verify Docker is running:
 
@@ -43,6 +44,12 @@ git clone https://github.com/OmniTrustILM/auth-opa-policies.git CZERTAINLY-Auth-
 git clone https://github.com/OmniTrustILM/scheduler.git CZERTAINLY-Scheduler
 ```
 
+Clone the Administrator frontend:
+
+```bash
+git clone https://github.com/OmniTrustILM/fe-administrator.git
+```
+
 Your directory structure should look like this:
 
 ```
@@ -50,7 +57,8 @@ ilm-local/
 ├── development-environment/
 ├── CZERTAINLY-Auth/
 ├── CZERTAINLY-Auth-OPA-Policies/
-└── CZERTAINLY-Scheduler/
+├── CZERTAINLY-Scheduler/
+└── fe-administrator/
 ```
 
 All other services (Core, RabbitMQ, OPA, PostgreSQL) use pre-built public images and do not require source repositories.
@@ -209,9 +217,70 @@ curl -s http://localhost:8280/api/v1/auth/profile \
 
 A successful response returns your administrator profile with role `superadmin` and a full list of permissions.
 
-## Step 8 — Stop the platform
+## Step 8 — Start the Administrator frontend
+
+The frontend is a separate Vite dev server that proxies API requests to the Core backend.
+
+Install dependencies:
 
 ```bash
+cd ~/ilm-local/fe-administrator
+npm install
+```
+
+Create the proxy configuration file at `src/setupProxy.js`. This tells Vite to forward all `/api` requests to the Core backend and authenticate them with the dummy administrator certificate:
+
+```bash
+curl -s https://raw.githubusercontent.com/OmniTrustILM/helm-charts/main/dummy-certificates/certs/admin.cert.pem \
+  | grep -A 999 "BEGIN CERTIFICATE" | grep -v "BEGIN\|END" | tr -d '\n' \
+  > /tmp/admin_cert_b64.txt
+
+CERT_URL=$(python3 -c "
+import urllib.parse
+print(urllib.parse.quote(open('/tmp/admin_cert_b64.txt').read().strip()))
+")
+
+cat > src/setupProxy.js << EOF
+const proxyConfig = {
+    server: {
+        proxy: {
+            '/api': {
+                target: 'http://localhost:8280',
+                changeOrigin: true,
+                secure: false,
+                headers: {
+                    'ssl-client-cert': '${CERT_URL}',
+                },
+            },
+        },
+    },
+};
+
+export default proxyConfig;
+EOF
+```
+
+Start the frontend:
+
+```bash
+npm start
+```
+
+The browser will open automatically at **http://localhost:5173**. Log in — the dummy administrator certificate is already injected via the proxy, so no login form is required.
+
+:::important
+The `src/setupProxy.js` file is gitignored. Each developer creates their own local copy with their certificate. Do not commit this file.
+:::
+
+## Step 9 — Stop the platform
+
+Stop the frontend with `Ctrl+C` in its terminal.
+
+Stop all backend services:
+
+```bash
+cd ~/ilm-local/development-environment
+
 docker compose -f czertainly-compose.yml -f postgres-compose.yml \
   --profile database --profile core down
 ```
@@ -228,3 +297,5 @@ Data in the database is persisted in the `./data/` directory. To reset the platf
 | Local API returns HTTP 401 from host | Local API is container-only | Use `docker exec core curl ...` instead of calling `localhost:8280` directly |
 | Authentication returns `Wrong format of user authentication certificate` | Certificate not URL-encoded | Use `urllib.parse.quote()` to URL-encode the certificate before sending |
 | `CZERTAINLY_SOURCES_BASE_DIR` not found | Wrong path in `.env` | Set the full absolute path to the directory containing `CZERTAINLY-Auth`, `CZERTAINLY-Auth-OPA-Policies`, `CZERTAINLY-Scheduler` |
+| Frontend shows blank page or API errors | `setupProxy.js` missing or wrong cert | Recreate `src/setupProxy.js` following Step 8 |
+| Frontend port 5173 already in use | Another Vite process running | Kill it with `lsof -ti:5173 \| xargs kill` |

--- a/docs/qa-strategy/local-setup.md
+++ b/docs/qa-strategy/local-setup.md
@@ -76,7 +76,7 @@ Open `.env` in any text editor and update `CZERTAINLY_SOURCES_BASE_DIR` to point
 # macOS:  /Users/yourname/ilm-local
 # Linux:  /home/yourname/ilm-local
 # WSL:    /home/yourname/ilm-local
-CZERTAINLY_SOURCES_BASE_DIR=<absolute path to ilm-local>
+CZERTAINLY_SOURCES_BASE_DIR=/Users/yourname/ilm-local
 ```
 
 All other values can be left at their defaults when using PostgreSQL in Docker.

--- a/docs/qa-strategy/local-setup.md
+++ b/docs/qa-strategy/local-setup.md
@@ -1,0 +1,230 @@
+---
+sidebar_position: 5
+---
+
+# Local Environment Setup
+
+This guide walks you through setting up the ILM platform locally using Docker Compose. By the end, you will have a fully running platform with all core services, a registered administrator, and a verified API connection — ready for writing automation tests.
+
+## Prerequisites
+
+Make sure the following are installed before you begin:
+
+- **Docker Desktop** — [docker.com/products/docker-desktop](https://www.docker.com/products/docker-desktop/). After installing, start it and wait until the Docker icon in the system tray stops animating.
+- **Git** — verify with `git --version` in the terminal.
+
+Verify Docker is running:
+
+```bash
+docker ps
+```
+
+If you see an error about the Docker daemon, Docker Desktop is not started yet.
+
+## Step 1 — Create a working directory and clone repositories
+
+Create a directory to hold all required repositories:
+
+```bash
+mkdir ~/ilm-local && cd ~/ilm-local
+```
+
+Clone the environment configuration repository:
+
+```bash
+git clone https://github.com/OmniTrustILM/development-environment.git
+```
+
+Clone the three services that are built from source. The folder names must match exactly as shown:
+
+```bash
+git clone https://github.com/OmniTrustILM/auth.git CZERTAINLY-Auth
+git clone https://github.com/OmniTrustILM/auth-opa-policies.git CZERTAINLY-Auth-OPA-Policies
+git clone https://github.com/OmniTrustILM/scheduler.git CZERTAINLY-Scheduler
+```
+
+Your directory structure should look like this:
+
+```
+ilm-local/
+├── development-environment/
+├── CZERTAINLY-Auth/
+├── CZERTAINLY-Auth-OPA-Policies/
+└── CZERTAINLY-Scheduler/
+```
+
+All other services (Core, RabbitMQ, OPA, PostgreSQL) use pre-built public images and do not require source repositories.
+
+## Step 2 — Configure environment variables
+
+```bash
+cd ~/ilm-local/development-environment
+cp .env.example .env
+```
+
+Open `.env` in any text editor and update `CZERTAINLY_SOURCES_BASE_DIR` to point to your working directory:
+
+```env
+CZERTAINLY_SOURCES_BASE_DIR=/Users/yourname/ilm-local
+```
+
+All other values can be left at their defaults when using PostgreSQL in Docker.
+
+:::note
+On macOS, files starting with `.` are hidden in Finder. Use `Cmd + Shift + .` to toggle their visibility, or edit them from the terminal.
+:::
+
+## Step 3 — Set up the trusted certificates file
+
+The Docker Compose setup requires this file to exist before starting, even if it is empty:
+
+```bash
+touch secrets/trusted_certificates.pem
+```
+
+For authenticating with the dummy administrator certificate (used in development), add the ILM Dummy Root CA to this file:
+
+```bash
+curl -s https://raw.githubusercontent.com/OmniTrustILM/helm-charts/main/dummy-certificates/certs/root-ca.cert.pem \
+  | grep -A 100 "BEGIN CERTIFICATE" \
+  >> secrets/trusted_certificates.pem
+```
+
+:::important
+Without the Dummy Root CA in this file, the Auth service will reject the dummy administrator certificate with `User client certificate is invalid`.
+:::
+
+## Step 4 — Start the platform
+
+```bash
+docker compose -f czertainly-compose.yml -f postgres-compose.yml \
+  --profile database --profile core up --build
+```
+
+The `--build` flag tells Docker to build the three source-based services on first run. This takes **10–20 minutes** the first time. Subsequent starts are much faster.
+
+To run in the background (detached mode):
+
+```bash
+docker compose -f czertainly-compose.yml -f postgres-compose.yml \
+  --profile database --profile core up --build -d
+```
+
+## Step 5 — Verify all services are running
+
+```bash
+docker compose -f czertainly-compose.yml -f postgres-compose.yml ps
+```
+
+All services should show status `healthy` or `Up`:
+
+| Service | Host port | Description |
+|---|---|---|
+| `postgres` | 2345 | PostgreSQL database |
+| `rabbitmq` | 5672 / 15672 | Message queue (UI at [localhost:15672](http://localhost:15672), login: `guest`/`guest`) |
+| `opa` | 8181 | Open Policy Agent |
+| `opa-bundles` | 8101 | OPA policy bundle server |
+| `auth` | 8100 | Authentication service |
+| `scheduler` | 8102 | Task scheduler |
+| `core` | 8280 | Core API |
+
+Confirm the Core API is up:
+
+```bash
+curl http://localhost:8280/api/v1/health/liveness
+# Expected: {"status":"UP"}
+```
+
+## Step 6 — Create the first administrator
+
+The platform uses X.509 certificate-based authentication. To register the first administrator, use the Local API.
+
+:::important
+The Local API is only accessible from **within the Core container**. Calling it directly from the host machine (e.g. `localhost:8280`) returns HTTP 401. Use `docker exec` as shown below.
+:::
+
+Save the administrator payload to a file:
+
+```bash
+cat > /tmp/first-admin.json << 'EOF'
+{
+  "username": "admin",
+  "firstname": "Admin",
+  "lastname": "Local",
+  "email": "admin@local.test",
+  "certificateData": "REPLACE_WITH_CERT_BASE64",
+  "enabled": "true",
+  "description": "First Administrator"
+}
+EOF
+```
+
+Get the dummy administrator certificate (base64-encoded DER):
+
+```bash
+curl -s https://raw.githubusercontent.com/OmniTrustILM/helm-charts/main/dummy-certificates/certs/admin.cert.pem \
+  | grep -A 999 "BEGIN CERTIFICATE" | grep -v "BEGIN\|END" | tr -d '\n' \
+  > /tmp/admin_cert_b64.txt
+```
+
+Update the payload with the certificate value:
+
+```bash
+CERT_B64=$(cat /tmp/admin_cert_b64.txt)
+sed -i.bak "s|REPLACE_WITH_CERT_BASE64|$CERT_B64|" /tmp/first-admin.json
+```
+
+Copy the file into the container and register the administrator:
+
+```bash
+docker cp /tmp/first-admin.json core:/tmp/first-admin.json
+
+docker exec core curl -s -X POST \
+  -H 'content-type: application/json' \
+  -d @/tmp/first-admin.json \
+  http://localhost:8080/api/v1/local/admins
+```
+
+A successful response returns a JSON object with the administrator's `uuid` and role `superadmin`.
+
+## Step 7 — Verify API authentication
+
+The platform authenticates API requests using the `ssl-client-cert` header. The certificate value must be **URL-encoded** — plain Base64 will fail because `+` characters are interpreted as spaces.
+
+Generate the URL-encoded certificate:
+
+```bash
+CERT_URL=$(python3 -c "
+import urllib.parse
+print(urllib.parse.quote(open('/tmp/admin_cert_b64.txt').read().strip()))
+")
+```
+
+Verify authentication:
+
+```bash
+curl -s http://localhost:8280/api/v1/auth/profile \
+  -H "ssl-client-cert: $CERT_URL" | python3 -m json.tool
+```
+
+A successful response returns your administrator profile with role `superadmin` and a full list of permissions.
+
+## Step 8 — Stop the platform
+
+```bash
+docker compose -f czertainly-compose.yml -f postgres-compose.yml \
+  --profile database --profile core down
+```
+
+Data in the database is persisted in the `./data/` directory. To reset the platform to a clean state, remove this directory before the next start.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `docker ps` fails with daemon error | Docker Desktop not started | Start Docker Desktop and wait for the icon to stop animating |
+| `docker compose up` fails on secrets mount | `secrets/trusted_certificates.pem` does not exist | Run `touch secrets/trusted_certificates.pem` |
+| Auth returns `User client certificate is invalid` | Dummy Root CA not in trusted certs | Add Root CA to `secrets/trusted_certificates.pem` and restart auth: `docker compose ... restart auth` |
+| Local API returns HTTP 401 from host | Local API is container-only | Use `docker exec core curl ...` instead of calling `localhost:8280` directly |
+| Authentication returns `Wrong format of user authentication certificate` | Certificate not URL-encoded | Use `urllib.parse.quote()` to URL-encode the certificate before sending |
+| `CZERTAINLY_SOURCES_BASE_DIR` not found | Wrong path in `.env` | Set the full absolute path to the directory containing `CZERTAINLY-Auth`, `CZERTAINLY-Auth-OPA-Policies`, `CZERTAINLY-Scheduler` |

--- a/docs/qa-strategy/local-setup.md
+++ b/docs/qa-strategy/local-setup.md
@@ -75,6 +75,7 @@ Open `.env` in any text editor and update `CZERTAINLY_SOURCES_BASE_DIR` to point
 ```env
 # macOS:  /Users/yourname/ilm-local
 # Linux:  /home/yourname/ilm-local
+# WSL:    /home/yourname/ilm-local
 CZERTAINLY_SOURCES_BASE_DIR=<absolute path to ilm-local>
 ```
 

--- a/docs/qa-strategy/local-setup.md
+++ b/docs/qa-strategy/local-setup.md
@@ -212,7 +212,7 @@ Verify authentication:
 
 ```bash
 curl -s http://localhost:8280/api/v1/auth/profile \
-  -H "ssl-client-cert: $CERT_URL" | jq
+  -H "ssl-client-cert: $CERT_URL"
 ```
 
 A successful response returns your administrator profile with role `superadmin` and a full list of permissions.
@@ -292,7 +292,7 @@ Data in the database is persisted in the `./data/` directory. To reset the platf
 | `docker compose up` fails on secrets mount | `secrets/trusted_certificates.pem` does not exist | Run `touch secrets/trusted_certificates.pem` |
 | Auth returns `User client certificate is invalid` | Dummy Root CA not in trusted certs | Add Root CA to `secrets/trusted_certificates.pem` and restart auth: `docker compose ... restart auth` |
 | Local API returns HTTP 401 from host | Port `8280` is the regular API requiring cert auth; Local API is on container-internal port `8080` only | Use `docker exec core curl ...` instead of calling `localhost:8280` directly |
-| Authentication returns `Wrong format of user authentication certificate` | Certificate not URL-encoded | Use `urllib.parse.quote()` to URL-encode the certificate before sending |
+| Authentication returns `Wrong format of user authentication certificate` | Certificate not URL-encoded | Use `node -e "console.log(encodeURIComponent('<base64_cert>'))"` to URL-encode the certificate before sending |
 | `CZERTAINLY_SOURCES_BASE_DIR` not found | Wrong path in `.env` | Set the full absolute path to the directory containing `auth`, `auth-opa-policies`, `scheduler` |
 | Frontend shows blank page or API errors | `setupProxy.js` missing or wrong cert | Recreate `src/setupProxy.js` following Step 8 |
 | Frontend port 5173 already in use | Another Vite process running | Kill it with `lsof -ti:5173 \| xargs kill` |

--- a/docs/qa-strategy/local-setup.md
+++ b/docs/qa-strategy/local-setup.md
@@ -36,12 +36,12 @@ Clone the environment configuration repository:
 git clone https://github.com/OmniTrustILM/development-environment.git
 ```
 
-Clone the three services that are built from source. The folder names must match exactly as shown — the repositories were renamed, but `czertainly-compose.yml` build paths still reference the original `CZERTAINLY-*` names:
+Clone the three services that are built from source:
 
 ```bash
-git clone https://github.com/OmniTrustILM/auth.git CZERTAINLY-Auth
-git clone https://github.com/OmniTrustILM/auth-opa-policies.git CZERTAINLY-Auth-OPA-Policies
-git clone https://github.com/OmniTrustILM/scheduler.git CZERTAINLY-Scheduler
+git clone https://github.com/OmniTrustILM/auth.git
+git clone https://github.com/OmniTrustILM/auth-opa-policies.git
+git clone https://github.com/OmniTrustILM/scheduler.git
 ```
 
 Clone the Administrator frontend:
@@ -55,9 +55,9 @@ Your directory structure should look like this:
 ```
 ilm-local/
 ├── development-environment/
-├── CZERTAINLY-Auth/
-├── CZERTAINLY-Auth-OPA-Policies/
-├── CZERTAINLY-Scheduler/
+├── auth/
+├── auth-opa-policies/
+├── scheduler/
 └── fe-administrator/
 ```
 
@@ -299,6 +299,6 @@ Data in the database is persisted in the `./data/` directory. To reset the platf
 | Auth returns `User client certificate is invalid` | Dummy Root CA not in trusted certs | Add Root CA to `secrets/trusted_certificates.pem` and restart auth: `docker compose ... restart auth` |
 | Local API returns HTTP 401 from host | Local API is container-only | Use `docker exec core curl ...` instead of calling `localhost:8280` directly |
 | Authentication returns `Wrong format of user authentication certificate` | Certificate not URL-encoded | Use `urllib.parse.quote()` to URL-encode the certificate before sending |
-| `CZERTAINLY_SOURCES_BASE_DIR` not found | Wrong path in `.env` | Set the full absolute path to the directory containing `CZERTAINLY-Auth`, `CZERTAINLY-Auth-OPA-Policies`, `CZERTAINLY-Scheduler` |
+| `CZERTAINLY_SOURCES_BASE_DIR` not found | Wrong path in `.env` | Set the full absolute path to the directory containing `auth`, `auth-opa-policies`, `scheduler` |
 | Frontend shows blank page or API errors | `setupProxy.js` missing or wrong cert | Recreate `src/setupProxy.js` following Step 8 |
 | Frontend port 5173 already in use | Another Vite process running | Kill it with `lsof -ti:5173 \| xargs kill` |


### PR DESCRIPTION
## Summary

Adds a step-by-step local environment setup guide to the QA Strategy section.

The guide was written based on hands-on testing of the Docker Compose setup and covers all non-obvious steps that are missing or incorrect in the current `development-environment` README.

Key things documented:
- Which repos to clone and with exactly what folder names
- `secrets/trusted_certificates.pem` must exist before `docker compose up`
- Dummy Root CA must be added to trusted certs for authentication to work
- Local API (`/api/v1/local/admins`) is only accessible via `docker exec` — not from the host machine
- `ssl-client-cert` header requires URL-encoded certificate value
- Troubleshooting table covering all common failure modes

## Why this belongs in QA Strategy

This guide serves as the entry point for anyone setting up the platform for testing — including new QA engineers and candidates completing take-home assignments. Having it in the QA Strategy section establishes it as the authoritative setup reference for testing purposes.

## Test plan

- [ ] Follow the guide from scratch on a clean machine
- [ ] Verify all services reach `healthy` status
- [ ] Verify admin creation via `docker exec`
- [ ] Verify API authentication with `ssl-client-cert` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)