### PR TITLE
fix(qa-strategy): overwrite trusted_certificates.pem in local-setup Step 3

### DIFF
--- a/docs/qa-strategy/local-setup.md
+++ b/docs/qa-strategy/local-setup.md
@@ -87,22 +87,15 @@ On macOS, files starting with `.` are hidden in Finder. Use `Cmd + Shift + .` to
 
 ## Step 3 — Set up the trusted certificates file
 
-The Docker Compose setup requires this file to exist before starting, even if it is empty:
-
-```bash
-touch secrets/trusted_certificates.pem
-```
-
-For authenticating with the dummy administrator certificate (used in development), add the ILM Dummy Root CA to this file:
+The `development-environment` repository ships with a `secrets/trusted_certificates.pem` file that contains a legacy CZERTAINLY Root CA — this is **not** the CA used to sign the dummy administrator certificate from `OmniTrustILM/helm-charts`. You need to overwrite it with the ILM Dummy Root CA, otherwise the Auth service will reject the dummy administrator certificate with `User client certificate is invalid`.
 
 ```bash
 curl -s https://raw.githubusercontent.com/OmniTrustILM/helm-charts/main/dummy-certificates/certs/root-ca.cert.pem \
-  | grep -A 100 "BEGIN CERTIFICATE" \
-  >> secrets/trusted_certificates.pem
+  > secrets/trusted_certificates.pem
 ```
 
 :::important
-Without the Dummy Root CA in this file, the Auth service will reject the dummy administrator certificate with `User client certificate is invalid`.
+Use `>` (overwrite), not `>>` (append). Appending leaves the legacy CA in the file and produces a malformed PEM concatenation, which breaks authentication later in Step 7.
 :::
 
 ## Step 4 — Start the platform
@@ -290,7 +283,7 @@ Data in the database is persisted in the `./data/` directory. To reset the platf
 |---|---|---|
 | `docker ps` fails with daemon error | Docker Desktop not started | Start Docker Desktop and wait for the icon to stop animating |
 | `docker compose up` fails on secrets mount | `secrets/trusted_certificates.pem` does not exist | Run `touch secrets/trusted_certificates.pem` |
-| Auth returns `User client certificate is invalid` | Dummy Root CA not in trusted certs | Add Root CA to `secrets/trusted_certificates.pem` and restart auth: `docker compose ... restart auth` |
+| Auth returns `User client certificate is invalid` (`unable to get local issuer certificate`) | `secrets/trusted_certificates.pem` does not contain the ILM Dummy Root CA, or was appended to instead of overwritten | Re-run the `curl` from Step 3 with `>` (overwrite). Verify only one cert with `grep -c "BEGIN CERTIFICATE" secrets/trusted_certificates.pem` — should return `1`. Then restart auth: `docker compose ... restart auth` |
 | Local API returns HTTP 401 from host | Port `8280` is the regular API requiring cert auth; Local API is on container-internal port `8080` only | Use `docker exec core curl ...` instead of calling `localhost:8280` directly |
 | Authentication returns `Wrong format of user authentication certificate` | Certificate not URL-encoded | Use `node -e "console.log(encodeURIComponent('<base64_cert>'))"` to URL-encode the certificate before sending |
 | `CZERTAINLY_SOURCES_BASE_DIR` not found | Wrong path in `.env` | Set the full absolute path to the directory containing `auth`, `auth-opa-policies`, `scheduler` |


### PR DESCRIPTION
## Summary

- Step 3 of `docs/qa-strategy/local-setup.md` used `>>` (append) to add the ILM Dummy Root CA to `secrets/trusted_certificates.pem`
- But the `development-environment` repository ships with a `secrets/trusted_certificates.pem` already committed, containing a legacy `CZERTAINLY Dummy Root CA` (different from the CA used to sign the dummy admin certificate in `OmniTrustILM/helm-charts`)
- Appending produced a malformed PEM with two concatenated certs (no newline between them), and the Auth service rejected the dummy admin certificate with `unable to get local issuer certificate`
- Switched to `>` (overwrite) so the file contains only the correct ILM Dummy Root CA
- Updated the troubleshooting entry with the specific error message and a verification command

## Reproduction (before this fix)

Following Step 3 as published, then running Step 7:

```
curl http://localhost:8280/api/v1/auth/profile -H "ssl-client-cert: $CERT_URL"
# Status: 401
```

Auth logs:

```
ERROR | User client certificate is invalid.: Certificate issued by 'CN=Dummy Root CA'
with subject 'CN=Administrator' is invalid: unable to get local issuer certificate
```

After the fix, Step 7 returns the administrator profile correctly and the frontend on `localhost:5173` opens directly into the admin UI (no "No login methods available").

## Test plan

- [x] Cleaned `~/ilm-local`, re-ran the guide from Step 1 on macOS
- [x] Confirmed Step 7 returns the administrator profile (200)
- [x] Confirmed the frontend opens authenticated at `localhost:5173`

## Follow-up

The committed `secrets/trusted_certificates.pem` in `OmniTrustILM/development-environment` is a legacy artifact and should either be removed or replaced with the ILM Dummy Root CA. I will open a separate issue/PR against `development-environment` to track this — once resolved, Step 3 can be simplified or dropped entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)