### PR TITLE
docs: rebrand the remaining CZERTAINLY references

### DIFF
--- a/docs/certificate-key/integration-guides/cert-manager-issuer/create-issuer.md
+++ b/docs/certificate-key/integration-guides/cert-manager-issuer/create-issuer.md
@@ -6,6 +6,10 @@ sidebar_position: 5
 
 The cert-manager issuer implements `czertainly-issuer.czertainly.com/v1alpha1` API that support both `CzertainlyClusterIssuer` and `CzertainlyIssuer` resources, and it allow you to configure the following `spec` field:
 
+:::note
+The API group and the resource kinds keep their original names in current releases. Use them exactly as written on this page — they are the identifiers the cluster resolves.
+:::
+
 | Field                              | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            | Mandatory                                     |
 |------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
 | `apiUrl`                           | URL to access the ILM platform API.                                                                                                                                                                                                                                                                                                                                                                                                                                                                 | <span class="badge badge--success">YES</span> |

--- a/docs/certificate-key/integration-guides/cert-manager-issuer/overview.md
+++ b/docs/certificate-key/integration-guides/cert-manager-issuer/overview.md
@@ -6,6 +6,10 @@ sidebar_position: 1
 
 This document outlines the steps necessary to be taken to integrate ILM with the [cert-manager](https://cert-manager.io/) `czertainly-issuer`.
 
+:::note[About the `czertainly-issuer` name]
+The issuer component, its Helm chart, its API group `czertainly-issuer.czertainly.com` and its `CzertainlyIssuer`/`CzertainlyClusterIssuer` resource kinds still carry their original names in current releases, so this guide uses them verbatim. Type them exactly as shown — these are live Kubernetes identifiers, and substituting the ILM name makes the commands and resources on the following pages fail.
+:::
+
 This integration guide was tested with:
 - Kubernetes 1.19+
 - cert-manager 1.7.0+

--- a/docs/signserver/upgrade-information/upgrade-1.0.13-1.14.0.md
+++ b/docs/signserver/upgrade-information/upgrade-1.0.13-1.14.0.md
@@ -4,13 +4,17 @@ sidebar_position: 160
 
 # From 1.0.13 To 1.14.0
 
-In release version `1.14.0` the following changes were made as part of the integration efforts with the CZERTAINLY platform:
+In release version `1.14.0` the following changes were made as part of the integration efforts with the platform:
 
 ## Change of the base package
 
-The base package was changed from `company.threekey` to `com.czertainly`. This change was made in accordance with the roadmap and integration efforts of the CZERTAINLY Signing with the platform and to prepare for next major release.
+The base package was changed from `company.threekey` to `com.czertainly`. This change was made in accordance with the roadmap and integration efforts of the signing component with the platform and to prepare for next major release.
 
 Each configuration consisting of the `company.threekey` module needs to be updated to `com.czertainly` in order to work with this new version.
+
+:::note[Package name is unchanged]
+`com.czertainly` is the Java base package shipped by the signing modules and it keeps that name in current releases, despite the platform being renamed to ILM. Type it exactly as shown — a configuration that uses any other package name will fail to load.
+:::
 
 ## Example of the change
 


### PR DESCRIPTION
A sweep of the remaining `czertainly` occurrences under `docs/`. Of 172 matches, only two were stale prose; everything else names something that still exists under that name, and renaming it would break a command or a link.

**Rebranded** — `docs/signserver/upgrade-information/upgrade-1.0.13-1.14.0.md`: "the CZERTAINLY platform" and "integration efforts of the CZERTAINLY Signing" now say "the platform" and "the signing component", matching the naming rule in `CLAUDE.md`. A note records that `com.czertainly` remains the Java base package, which is why the worker properties on that page keep it.

**Kept, with a clarifying note added** — the cert-manager issuer pages. The chart `czertainly-issuer`, the API group `czertainly-issuer.czertainly.com`, the kinds `CzertainlyIssuer` and `CzertainlyClusterIssuer`, and the certificate-uuid annotation are all still literally these names on `OmniTrustILM/cert-manager-issuer` `main`, so `kubectl` would fail with anything else. The notes stop the names from reading as documentation that was never updated.

**Left unchanged** — the `com.czertainly.*` class names throughout the SignServer worker properties, the appliance's `/etc/czertainly-ansible/` path and `czertainly` user (already backticked and version-qualified next to the page's own rename note), the third-party `playbook-czertainly-acme-demo.yml` filename, and the redirect sources in `docusaurus.config.js`, which are previously published URLs.
